### PR TITLE
feat: unify join and create into a single smart input box

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -9,7 +9,9 @@ A real-time, multi-room agenda timer for standups, retros, planning sessions —
 ## Features
 
 ### Multi-Room System
-- **Lobby / Home screen** — create a new room or join an existing one by 6-character code
+- **Smart entry box** — a single unified input that auto-detects intent: type a 6-character code to join an existing room, or type a name to create a new one
+- **Live room lookup** — when a 6-char code is entered, the app probes Ably presence in real time to check if the room exists and shows the active member count
+- **Create with custom codes** — if a 6-char code doesn't match an existing room, it creates a new room with that exact code
 - **Public & Private rooms** — toggle visibility when creating; public rooms appear in the lobby with live member counts
 - **Room names** — optionally name your room (displayed in the lobby and in the room bar)
 - **Shareable links** — copy a room code or direct URL to invite others
@@ -46,7 +48,9 @@ A real-time, multi-room agenda timer for standups, retros, planning sessions —
 ## How It Works
 
 1. Open the app — you land on the **Lobby**
-2. **Create a room** (set a name, choose public or private) or **join by code**
+2. **Type in the smart box** — paste a room code to join, or type a room name to create
+   - If the code matches an active room, you'll see the member count and can join instantly
+   - If the code doesn't match (or you type a name), it creates a new room
 3. Share the 6-character room code or direct link with your team
 4. Everyone types their name and hits **Join** — the queue builds in real time
 5. Hit **▶ Start Session** to kick off the first speaker
@@ -138,12 +142,13 @@ src/
     useAblyNotes.js       # Room-scoped Ably channel for shared notes
     useLobby.js           # Lobby channel — public room list
     useRoom.js            # Hash routing, room ID generation, navigation
+    useRoomLookup.js      # Debounced Ably presence probe — checks if a room exists
     useRoomPresence.js    # Ably presence tracking per room
     useTimer.js           # Countdown timer logic
     useTheme.js           # Dark/light theme toggle
     useToast.js           # Toast notification
   components/
-    HomeScreen.jsx        # Lobby — create room, join by code, public room list
+    HomeScreen.jsx        # Lobby — unified smart input (join/create), public room list
     Room.jsx              # Full room view (queue, timer, notes)
     RoomBar.jsx           # Room header bar (code, name, share buttons, presence)
     Header.jsx            # Logo, connection status, queue count

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -14,7 +14,15 @@ export default function App() {
   const [roomConfig, setRoomConfig] = useState(null)
 
   const handleCreateRoom = useCallback((config) => {
-    const id = createRoom()
+    // If a specific room ID was requested (e.g. user typed a 6-char code
+    // that doesn't map to an existing room), use it; otherwise generate one.
+    let id
+    if (config.id) {
+      id = config.id
+      joinRoom(id) // navigate to the room
+    } else {
+      id = createRoom()
+    }
     const cfg = { ...config, id }
     roomConfigRef.current = cfg
     setRoomConfig(cfg)
@@ -30,7 +38,7 @@ export default function App() {
         })
       }, 500)
     }
-  }, [createRoom, publishRoomUpdate])
+  }, [createRoom, joinRoom, publishRoomUpdate])
 
   const handleJoinRoom = useCallback((code) => {
     const cfg = { isPublic: false, name: '', id: code }

--- a/src/components/HomeScreen.jsx
+++ b/src/components/HomeScreen.jsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef } from 'react'
 import { useLobby } from '../hooks/useLobby'
+import { useRoomLookup } from '../hooks/useRoomLookup'
 import { ThemeToggle } from './ThemeToggle'
 import styles from './HomeScreen.module.css'
 
@@ -29,31 +30,49 @@ const IconGlobe = () => (
 )
 
 export function HomeScreen({ onCreateRoom, onJoinRoom, theme, onThemeToggle }) {
-  const [joinCode, setJoinCode] = useState('')
-  const [joinError, setJoinError] = useState('')
+  const [input, setInput] = useState('')
   const [isPublic, setIsPublic] = useState(false)
-  const [roomName, setRoomName] = useState('')
+  const [error, setError] = useState('')
   const { publicRooms } = useLobby()
   const inputRef = useRef(null)
 
   useEffect(() => {
-    if (joinError) {
-      const t = setTimeout(() => setJoinError(''), 3000)
+    if (error) {
+      const t = setTimeout(() => setError(''), 3000)
       return () => clearTimeout(t)
     }
-  }, [joinError])
+  }, [error])
 
-  const handleJoinByCode = () => {
-    const cleaned = joinCode.trim().toUpperCase().replace(/[^A-Z0-9]/g, '')
-    if (cleaned.length !== 6) {
-      setJoinError('Code must be 6 characters')
-      return
+  // Detect whether input looks like a 6-char room code
+  const cleaned = input.trim().toUpperCase().replace(/[^A-Z0-9]/g, '')
+  const is6Char = cleaned.length === 6 && input.trim().length === 6
+  const isEmpty = input.trim().length === 0
+
+  // Live-check Ably presence to see if a room with this code exists
+  const { exists: roomExists, memberCount: lookupCount, checking } = useRoomLookup(input)
+
+  // Mode logic:
+  //   empty          → neutral
+  //   6-char + exists → join
+  //   6-char + checking → checking (show spinner)
+  //   anything else   → create (including 6-char codes with no active room)
+  const mode = isEmpty
+    ? 'neutral'
+    : is6Char && checking
+      ? 'checking'
+      : is6Char && roomExists
+        ? 'join'
+        : 'create'
+
+  const handleSubmit = () => {
+    const trimmed = input.trim()
+    if (!trimmed || mode === 'checking') return
+    if (mode === 'join') {
+      onJoinRoom(cleaned)
+    } else {
+      // For 6-char codes that don't match an existing room, create with that specific code
+      onCreateRoom({ isPublic, name: trimmed, ...(is6Char ? { id: cleaned } : {}) })
     }
-    onJoinRoom(cleaned)
-  }
-
-  const handleCreateRoom = () => {
-    onCreateRoom({ isPublic, name: roomName.trim() })
   }
 
   // Sort rooms: most members first
@@ -79,53 +98,74 @@ export function HomeScreen({ onCreateRoom, onJoinRoom, theme, onThemeToggle }) {
           <ThemeToggle theme={theme} onToggle={onThemeToggle} />
         </div>
 
-        {/* Quick actions — Join (left, smaller) then Create (right, bigger) */}
-        <div className={styles.actions}>
-          {/* Join by code */}
-          <div className={`${styles.card} ${styles.cardJoin}`}>
-            <div className={styles.cardLabel}>JOIN</div>
-            <div className={styles.cardContent}>
-              <p className={styles.cardDesc}>Enter a 6-character room code</p>
-              <div className={styles.joinRow}>
-                <input
-                  ref={inputRef}
-                  className={`${styles.codeInput} ${joinError ? styles.codeInputError : ''}`}
-                  type="text"
-                  placeholder="ABC123"
-                  maxLength={6}
-                  autoComplete="off"
-                  spellCheck={false}
-                  value={joinCode}
-                  onChange={(e) => {
-                    setJoinCode(e.target.value.toUpperCase().replace(/[^A-Z0-9]/g, ''))
-                    setJoinError('')
-                  }}
-                  onKeyDown={(e) => e.key === 'Enter' && handleJoinByCode()}
-                />
-                <button className="btn btn-blue" onClick={handleJoinByCode}>
-                  JOIN <IconArrowRight />
-                </button>
-              </div>
-              {joinError && <div className={styles.error}>{joinError}</div>}
-            </div>
+        {/* Unified smart box */}
+        <div className={[
+          styles.smartBox,
+          mode === 'join' && styles.smartBoxJoin,
+          mode === 'create' && styles.smartBoxCreate,
+          mode === 'checking' && styles.smartBoxChecking,
+        ].filter(Boolean).join(' ')}>
+          <div className={styles.cardLabel}>
+            {mode === 'join' ? 'JOIN ROOM' : mode === 'checking' ? 'CHECKING…' : mode === 'create' ? 'CREATE ROOM' : 'ENTER ROOM'}
           </div>
+          <div className={styles.cardContent}>
+            <div className={styles.inputRow}>
+              <input
+                ref={inputRef}
+                className={[
+                  styles.smartInput,
+                  (mode === 'join' || mode === 'checking') && styles.smartInputJoin,
+                  mode === 'create' && styles.smartInputCreate,
+                  error && styles.smartInputError,
+                ].filter(Boolean).join(' ')}
+                type="text"
+                placeholder="paste a room code or type a name to create..."
+                maxLength={40}
+                autoComplete="off"
+                spellCheck={false}
+                value={input}
+                onChange={(e) => {
+                  setInput(e.target.value)
+                  setError('')
+                }}
+                onKeyDown={(e) => e.key === 'Enter' && handleSubmit()}
+              />
+              <button
+                className={`btn ${mode === 'join' ? 'btn-blue' : 'btn-amber'}`}
+                disabled={isEmpty || mode === 'checking'}
+                onClick={handleSubmit}
+              >
+                {mode === 'join' ? <>JOIN <IconArrowRight /></> : <>⚡ CREATE</>}
+              </button>
+            </div>
 
-          {/* Create room */}
-          <div className={`${styles.card} ${styles.cardCreate}`}>
-            <div className={styles.cardLabel}>CREATE</div>
-            <div className={styles.cardContent}>
-              <div className={styles.nameRow}>
-                <label className={styles.fieldLabel}>ROOM NAME (OPTIONAL)</label>
-                <input
-                  className={styles.input}
-                  type="text"
-                  placeholder="e.g. Sprint Review, Team Standup..."
-                  maxLength={40}
-                  value={roomName}
-                  onChange={(e) => setRoomName(e.target.value)}
-                />
-              </div>
+            {/* Hint text */}
+            <div className={styles.hintRow}>
+              {mode === 'checking' && (
+                <span className={styles.hintChecking}>
+                  <span className={styles.dot}>●</span> LOOKING UP ROOM…
+                </span>
+              )}
+              {mode === 'join' && (
+                <span className={styles.hintJoin}>
+                  <IconUsers /> <strong>{lookupCount}</strong> ACTIVE — PRESS ENTER TO JOIN
+                </span>
+              )}
+              {mode === 'create' && is6Char && (
+                <span className={styles.hintCreate}>NO ROOM "{cleaned}" FOUND — THIS WILL CREATE IT</span>
+              )}
+              {mode === 'create' && !is6Char && (
+                <span className={styles.hintCreate}>↵ THIS WILL CREATE A NEW ROOM</span>
+              )}
+              {mode === 'neutral' && (
+                <span className={styles.hintNeutral}>TYPE A 6-CHARACTER CODE TO JOIN, OR A ROOM NAME TO CREATE</span>
+              )}
+            </div>
 
+            {error && <div className={styles.error}>{error}</div>}
+
+            {/* Create-mode options (visibility toggle) — slides in */}
+            <div className={`${styles.createOptions} ${mode === 'create' ? styles.createOptionsVisible : ''}`}>
               <div className={styles.toggleRow}>
                 <span className={styles.toggleLabel}>VISIBILITY</span>
                 <div className={styles.visPills}>
@@ -143,10 +183,6 @@ export function HomeScreen({ onCreateRoom, onJoinRoom, theme, onThemeToggle }) {
                   </button>
                 </div>
               </div>
-
-              <button className="btn btn-amber" style={{ width: '100%' }} onClick={handleCreateRoom}>
-                ⚡ CREATE ROOM
-              </button>
             </div>
           </div>
         </div>

--- a/src/components/HomeScreen.module.css
+++ b/src/components/HomeScreen.module.css
@@ -79,34 +79,34 @@
   color: var(--text-dim);
 }
 
-/* ── Action cards ── */
-.actions {
-  display: grid;
-  grid-template-columns: 2fr 3fr;
-  gap: 16px;
-  margin-bottom: 36px;
-  align-items: start;
-}
-
-@media (max-width: 600px) {
-  .actions {
-    grid-template-columns: 1fr;
-  }
-}
-
-.card {
+/* ── Smart Box (unified join/create) ── */
+.smartBox {
   background: var(--surface);
   border: 1px solid var(--border);
-  padding: 24px 20px 20px;
+  padding: 28px 24px 22px;
   position: relative;
+  margin-bottom: 36px;
+  transition: border-color 0.2s, box-shadow 0.25s;
 }
 
-.cardCreate {
-  /* Emphasise the create card */
+.smartBoxJoin {
+  border-color: rgba(77, 166, 255, 0.3);
+  box-shadow: 0 0 24px rgba(77, 166, 255, 0.05);
 }
 
-.cardJoin {
-  /* Compact join card */
+.smartBoxCreate {
+  border-color: rgba(245, 166, 35, 0.3);
+  box-shadow: 0 0 24px rgba(245, 166, 35, 0.05);
+}
+
+.smartBoxChecking {
+  border-color: var(--border-bright);
+  animation: borderPulse 1.2s ease-in-out infinite;
+}
+
+@keyframes borderPulse {
+  0%, 100% { border-color: var(--border); }
+  50% { border-color: var(--border-bright); }
 }
 
 .cardLabel {
@@ -121,34 +121,160 @@
   padding: 2px 10px;
   border: 1px solid var(--border);
   transform: translateY(-50%);
+  transition: color 0.2s, border-color 0.2s;
+}
+
+.smartBoxJoin .cardLabel {
+  color: var(--blue);
+  border-color: rgba(77, 166, 255, 0.3);
 }
 
 .cardContent {
   display: flex;
   flex-direction: column;
-  gap: 14px;
+  gap: 12px;
 }
 
-.cardDesc {
+/* ── Input row ── */
+.inputRow {
+  display: flex;
+  gap: 10px;
+  align-items: stretch;
+}
+
+.smartInput {
+  flex: 1;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  color: var(--text);
   font-family: 'IBM Plex Mono', monospace;
-  font-size: 12px;
+  font-size: 14px;
+  padding: 12px 16px;
+  outline: none;
+  transition: border-color 0.2s, box-shadow 0.2s, font-family 0.15s, letter-spacing 0.2s;
+  letter-spacing: 0.04em;
+  min-width: 0;
+}
+
+.smartInput::placeholder {
   color: var(--text-dim);
-  line-height: 1.5;
+  font-style: italic;
+  opacity: 0.6;
 }
 
-.cardButtons {
-  display: flex;
-  gap: 8px;
-  flex-wrap: wrap;
+.smartInput:focus {
+  border-color: var(--amber);
+  box-shadow: 0 0 0 2px var(--amber-glow);
 }
 
-/* ── Create form ── */
-.createForm {
-  display: flex;
-  flex-direction: column;
-  gap: 14px;
+.smartInputJoin {
+  font-family: 'Orbitron', monospace;
+  font-size: 18px;
+  font-weight: 700;
+  letter-spacing: 0.3em;
+  text-align: center;
+  text-transform: uppercase;
 }
 
+.smartInputJoin:focus {
+  border-color: var(--blue);
+  box-shadow: 0 0 0 2px var(--blue-glow);
+}
+
+.smartInputCreate:focus {
+  border-color: var(--amber);
+  box-shadow: 0 0 0 2px var(--amber-glow);
+}
+
+.smartInputError {
+  border-color: var(--red);
+  box-shadow: 0 0 0 2px var(--red-glow);
+}
+
+/* ── Hint text ── */
+.hintRow {
+  min-height: 16px;
+  transition: opacity 0.2s;
+}
+
+.hintRow span {
+  font-family: 'Share Tech Mono', monospace;
+  font-size: 10px;
+  letter-spacing: 0.15em;
+  animation: hintFadeIn 0.2s ease;
+}
+
+.hintJoin {
+  color: var(--blue);
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.hintJoin svg {
+  stroke: var(--blue);
+}
+
+.hintJoin strong {
+  font-weight: 700;
+  color: var(--blue);
+}
+
+.hintCreate {
+  color: var(--amber);
+}
+
+.hintNeutral {
+  color: var(--text-dim);
+}
+
+.hintChecking {
+  color: var(--text-dim);
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.dot {
+  animation: dotPulse 1s ease-in-out infinite;
+  font-size: 8px;
+}
+
+@keyframes dotPulse {
+  0%, 100% { opacity: 0.3; }
+  50% { opacity: 1; }
+}
+
+@keyframes hintFadeIn {
+  from { opacity: 0; transform: translateY(-4px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+/* ── Create-mode options (slide in) ── */
+.createOptions {
+  max-height: 0;
+  opacity: 0;
+  overflow: hidden;
+  transition: max-height 0.25s ease, opacity 0.2s ease, padding 0.25s ease;
+  padding-top: 0;
+  border-top: 1px solid transparent;
+}
+
+.createOptionsVisible {
+  max-height: 60px;
+  opacity: 1;
+  padding-top: 12px;
+  border-top-color: var(--border);
+}
+
+.error {
+  font-family: 'Share Tech Mono', monospace;
+  font-size: 10px;
+  letter-spacing: 0.15em;
+  color: var(--red);
+}
+
+/* ── Shared form elements ── */
 .toggleRow {
   display: flex;
   align-items: center;
@@ -210,89 +336,6 @@
 
 .visPillActivePublic svg {
   stroke: var(--green);
-}
-
-.nameRow {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-}
-
-.fieldLabel {
-  font-family: 'Share Tech Mono', monospace;
-  font-size: 9px;
-  letter-spacing: 0.2em;
-  color: var(--text-dim);
-}
-
-.input {
-  background: var(--bg);
-  border: 1px solid var(--border);
-  color: var(--text);
-  font-family: 'IBM Plex Mono', monospace;
-  font-size: 13px;
-  padding: 10px 14px;
-  outline: none;
-  transition: border-color 0.2s, box-shadow 0.2s;
-}
-
-.input::placeholder {
-  color: var(--text-dim);
-  font-style: italic;
-  opacity: 0.6;
-}
-
-.input:focus {
-  border-color: var(--amber);
-  box-shadow: 0 0 0 2px var(--amber-glow);
-}
-
-/* ── Join by code ── */
-.joinRow {
-  display: flex;
-  gap: 10px;
-  align-items: stretch;
-}
-
-.codeInput {
-  flex: 1;
-  background: var(--bg);
-  border: 1px solid var(--border);
-  color: var(--text);
-  font-family: 'Orbitron', monospace;
-  font-size: 18px;
-  font-weight: 700;
-  letter-spacing: 0.3em;
-  padding: 10px 14px;
-  outline: none;
-  text-align: center;
-  text-transform: uppercase;
-  transition: border-color 0.2s, box-shadow 0.2s;
-  min-width: 0;
-}
-
-.codeInput::placeholder {
-  font-size: 14px;
-  letter-spacing: 0.15em;
-  opacity: 0.3;
-  font-weight: 400;
-}
-
-.codeInput:focus {
-  border-color: var(--blue);
-  box-shadow: 0 0 0 2px var(--blue-glow);
-}
-
-.codeInputError {
-  border-color: var(--red);
-  box-shadow: 0 0 0 2px var(--red-glow);
-}
-
-.error {
-  font-family: 'Share Tech Mono', monospace;
-  font-size: 10px;
-  letter-spacing: 0.15em;
-  color: var(--red);
 }
 
 /* ── Lobby ── */

--- a/src/hooks/useRoomLookup.js
+++ b/src/hooks/useRoomLookup.js
@@ -1,0 +1,83 @@
+import { useEffect, useRef, useState } from 'react'
+import Ably from 'ably'
+
+/**
+ * Probes Ably presence to check if a room exists (has active members).
+ * Debounces lookups by 300ms so we don't hammer the API on every keystroke.
+ *
+ * @param {string} roomCode – raw user input
+ * @returns {{ exists: boolean, memberCount: number, checking: boolean }}
+ */
+export function useRoomLookup(roomCode) {
+  const clientRef = useRef(null)
+  const isMounted = useRef(true)
+  const [result, setResult] = useState({ exists: false, memberCount: 0, checking: false })
+
+  // Maintain a single Ably client while the component is mounted
+  useEffect(() => {
+    isMounted.current = true
+
+    const apiKey = import.meta.env.VITE_ABLY_API_KEY
+    if (!apiKey) return
+
+    let client
+    try {
+      client = new Ably.Realtime({
+        key: apiKey,
+        clientId: 'lookup-' + Math.random().toString(36).slice(2),
+      })
+    } catch {
+      return
+    }
+    clientRef.current = client
+
+    return () => {
+      isMounted.current = false
+      client.close()
+      clientRef.current = null
+    }
+  }, [])
+
+  // Debounced presence check whenever the code changes
+  useEffect(() => {
+    const cleaned = roomCode?.trim().toUpperCase().replace(/[^A-Z0-9]/g, '')
+
+    // Only probe when input is exactly 6 alphanumeric chars
+    if (!cleaned || cleaned.length !== 6 || roomCode?.trim().length !== 6) {
+      setResult({ exists: false, memberCount: 0, checking: false })
+      return
+    }
+
+    setResult((prev) => ({ ...prev, checking: true }))
+
+    const timer = setTimeout(async () => {
+      const client = clientRef.current
+      if (!client || !isMounted.current) return
+
+      try {
+        const channelName = `lightning-ladder__room_${cleaned}__presence`
+        const channel = client.channels.get(channelName)
+        const members = await channel.presence.get()
+
+        if (isMounted.current) {
+          setResult({
+            exists: members.length > 0,
+            memberCount: members.length,
+            checking: false,
+          })
+        }
+
+        // Detach so we don't keep an idle channel subscription open
+        channel.detach()
+      } catch {
+        if (isMounted.current) {
+          setResult({ exists: false, memberCount: 0, checking: false })
+        }
+      }
+    }, 300)
+
+    return () => clearTimeout(timer)
+  }, [roomCode])
+
+  return result
+}


### PR DESCRIPTION
Replace the two-card (Join / Create) layout with one adaptive input that auto-detects user intent:

- Type a 6-char code → live Ably presence lookup checks if room exists
  - Room found → shows active member count, JOIN button (blue)
  - Room not found → flips to CREATE mode with that exact code
- Type anything else → CREATE mode with room name + visibility toggle
- Visibility toggle slides in only when in create mode

New hook: useRoomLookup — debounced (300ms) Ably presence probe that returns { exists, memberCount, checking }.

App.jsx updated to support creating rooms with a caller-specified ID so users can create rooms with custom 6-char codes (e.g. SPRINT).

README updated to reflect the new unified entry flow.

Closes #6