### PR TITLE
fix: redesign room layout — remove header, make timer central

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lightning-ladder",
   "private": true,
-  "version": "0.0.0",
+  "version": "3.1.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/readme.md
+++ b/readme.md
@@ -39,6 +39,8 @@ A real-time, multi-room agenda timer for standups, retros, planning sessions —
 - **Unread notification** — pulsing dot when someone edits notes while your panel is collapsed
 
 ### Polish
+- **Compact room layout** — no redundant title in-room; timer and controls are visible without scrolling
+- **Unified room bar** — room name, connection status, member count, remaining speakers, share buttons, and theme toggle all in one header
 - **Dark / Light theme** — toggle with system preference detection
 - **Sync status** — footer shows live connection state and app version
 - **Consistent SVG stroke icons** throughout (no emoji mix)
@@ -150,8 +152,8 @@ src/
   components/
     HomeScreen.jsx        # Lobby — unified smart input (join/create), public room list
     Room.jsx              # Full room view (queue, timer, notes)
-    RoomBar.jsx           # Room header bar (code, name, share buttons, presence)
-    Header.jsx            # Logo, connection status, queue count
+    RoomBar.jsx           # Room header — name, status, presence, share, remaining, theme
+    Header.jsx            # Lobby logo, connection status, queue count
     JoinSection.jsx       # Name input + timer config
     TimerPanel.jsx        # Active speaker timer + phase controls
     RosterItem.jsx        # Individual speaker row (edit/move/delete)

--- a/src/App.module.css
+++ b/src/App.module.css
@@ -130,7 +130,7 @@
   z-index: 1;
   max-width: 880px;
   margin: 0 auto;
-  padding: 32px 24px 80px;
+  padding: 16px 24px 60px;
   flex: 1;
   min-width: 0;
 }

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -1,6 +1,6 @@
 import styles from './Footer.module.css'
 
-const VERSION = 'v3.0'
+const VERSION = 'v3.1'
 
 export function Footer({ isConnected, isConnecting }) {
   const dotClass = isConnecting

--- a/src/components/Footer.module.css
+++ b/src/components/Footer.module.css
@@ -1,6 +1,6 @@
 .footer {
-  margin-top: 60px;
-  padding-top: 20px;
+  margin-top: 32px;
+  padding-top: 16px;
   border-top: 1px solid var(--border);
   display: flex;
   align-items: center;

--- a/src/components/JoinSection.module.css
+++ b/src/components/JoinSection.module.css
@@ -1,8 +1,8 @@
 .section {
   background: var(--surface);
   border: 1px solid var(--border);
-  padding: 28px 24px 20px;
-  margin-bottom: 28px;
+  padding: 22px 20px 16px;
+  margin-bottom: 18px;
   position: relative;
 }
 

--- a/src/components/Room.jsx
+++ b/src/components/Room.jsx
@@ -3,7 +3,6 @@ import { useAbly } from '../hooks/useAbly'
 import { useToast } from '../hooks/useToast'
 import { useRoomPresence } from '../hooks/useRoomPresence'
 import { useLobby } from '../hooks/useLobby'
-import { Header } from './Header'
 import { RoomBar } from './RoomBar'
 import { JoinSection } from './JoinSection'
 import { TimerPanel } from './TimerPanel'
@@ -338,29 +337,17 @@ export function Room({ roomId, roomUrl, roomConfig, theme, onThemeToggle, onLeav
       </aside>
 
       <div className={styles.app}>
-        <Header
-          speakerCount={state.speakers.length}
-          remaining={waiting.length + (active ? 1 : 0)}
-          isConnected={isConnected}
-          isConnecting={isConnecting}
-          theme={theme}
-          onThemeToggle={onThemeToggle}
-        />
-
         <RoomBar
           roomId={roomId}
           roomUrl={roomUrl}
           roomName={roomConfig?.name || ''}
           memberCount={memberCount}
+          remaining={waiting.length + (active ? 1 : 0)}
+          isConnected={isConnected}
+          isConnecting={isConnecting}
+          theme={theme}
+          onThemeToggle={onThemeToggle}
           onLeave={handleLeave}
-        />
-
-        <JoinSection
-          presentMins={state.presentMins}
-          qaMins={state.qaMins}
-          onJoin={joinQueue}
-          onChangePresentMins={(v) => updateState((p) => ({ ...p, presentMins: v }))}
-          onChangeQaMins={(v) => updateState((p) => ({ ...p, qaMins: v }))}
         />
 
         {active && (
@@ -373,6 +360,14 @@ export function Room({ roomId, roomUrl, roomConfig, theme, onThemeToggle, onLeav
             onExpired={handleExpired}
           />
         )}
+
+        <JoinSection
+          presentMins={state.presentMins}
+          qaMins={state.qaMins}
+          onJoin={joinQueue}
+          onChangePresentMins={(v) => updateState((p) => ({ ...p, presentMins: v }))}
+          onChangeQaMins={(v) => updateState((p) => ({ ...p, qaMins: v }))}
+        />
 
         {/* Roster */}
         <div className={styles.rosterHeader}>

--- a/src/components/RoomBar.jsx
+++ b/src/components/RoomBar.jsx
@@ -1,4 +1,5 @@
 import { useState, useCallback } from 'react'
+import { ThemeToggle } from './ThemeToggle'
 import styles from './RoomBar.module.css'
 
 /* ── SVG Icons (stroke style, matching ThemeToggle) ── */
@@ -26,7 +27,7 @@ const IconCheck = () => (
   </svg>
 )
 
-export function RoomBar({ roomId, roomUrl, roomName, memberCount, onLeave }) {
+export function RoomBar({ roomId, roomUrl, roomName, memberCount, remaining, isConnected, isConnecting, theme, onThemeToggle, onLeave }) {
   const [copied, setCopied] = useState(null) // 'link' | 'code' | null
 
   const copyToClipboard = useCallback((text, type) => {
@@ -46,40 +47,82 @@ export function RoomBar({ roomId, roomUrl, roomName, memberCount, onLeave }) {
     })
   }, [])
 
+  const dotClass = isConnecting
+    ? styles.dotConnecting
+    : isConnected
+    ? styles.dotLive
+    : styles.dotOffline
+
+  const statusText = isConnecting
+    ? 'CONNECTING'
+    : isConnected
+    ? 'LIVE'
+    : 'OFFLINE'
+
   return (
     <div className={styles.bar}>
-      <div className={styles.left}>
-        <button className={styles.backBtn} onClick={onLeave} title="Back to lobby">
-          <IconArrowLeft /> LOBBY
-        </button>
-        <div className={styles.sep} />
-        <div className={styles.roomInfo}>
-          <span className={styles.label}>ROOM</span>
-          <span className={styles.code}>{roomId}</span>
-          {roomName && <span className={styles.roomName}>{roomName}</span>}
+      {/* Top row: back button, room title, share & theme */}
+      <div className={styles.topRow}>
+        <div className={styles.topLeft}>
+          <button className={styles.backBtn} onClick={onLeave} title="Back to lobby">
+            <IconArrowLeft /> LOBBY
+          </button>
+          <div className={styles.sep} />
+          <div className={styles.roomTitle}>
+            <span className={styles.bolt}>⚡</span>
+            {roomName ? (
+              <span className={styles.roomNameBig}>{roomName}</span>
+            ) : (
+              <span className={styles.roomNameBig}>ROOM {roomId}</span>
+            )}
+          </div>
         </div>
-        <div className={styles.sep} />
-        <div className={styles.presence}>
-          <span className={styles.presenceDot} />
-          <span className={styles.presenceCount}>{memberCount}</span>
-          <span className={styles.presenceLabel}>CONNECTED</span>
+        <div className={styles.topRight}>
+          <button
+            className={`${styles.shareBtn} ${copied === 'code' ? styles.shareCopied : ''}`}
+            onClick={() => copyToClipboard(roomId, 'code')}
+            title="Copy room code"
+          >
+            {copied === 'code' ? <><IconCheck /> COPIED</> : <><IconCopy /> CODE</>}
+          </button>
+          <button
+            className={`${styles.shareBtn} ${copied === 'link' ? styles.shareCopied : ''}`}
+            onClick={() => copyToClipboard(roomUrl, 'link')}
+            title="Copy room link"
+          >
+            {copied === 'link' ? <><IconCheck /> COPIED</> : <><IconLink /> LINK</>}
+          </button>
+          <ThemeToggle theme={theme} onToggle={onThemeToggle} />
         </div>
       </div>
-      <div className={styles.right}>
-        <button
-          className={`${styles.shareBtn} ${copied === 'code' ? styles.shareCopied : ''}`}
-          onClick={() => copyToClipboard(roomId, 'code')}
-          title="Copy room code"
-        >
-          {copied === 'code' ? <><IconCheck /> COPIED</> : <><IconCopy /> CODE</>}
-        </button>
-        <button
-          className={`${styles.shareBtn} ${copied === 'link' ? styles.shareCopied : ''}`}
-          onClick={() => copyToClipboard(roomUrl, 'link')}
-          title="Copy room link"
-        >
-          {copied === 'link' ? <><IconCheck /> COPIED</> : <><IconLink /> LINK</>}
-        </button>
+
+      {/* Bottom row: status strip */}
+      <div className={styles.statusStrip}>
+        <div className={styles.statusLeft}>
+          <div className={styles.statusItem}>
+            <div className={`${styles.statusDot} ${dotClass}`} />
+            <span>{statusText}</span>
+          </div>
+          <div className={styles.statusSep} />
+          <div className={styles.statusItem}>
+            <span className={styles.presenceDot} />
+            <span>{memberCount} CONNECTED</span>
+          </div>
+          {roomName && (
+            <>
+              <div className={styles.statusSep} />
+              <div className={styles.statusItem}>
+                <span className={styles.statusCode}>CODE: {roomId}</span>
+              </div>
+            </>
+          )}
+        </div>
+        <div className={styles.statusRight}>
+          <div className={styles.remainingBadge}>
+            <span className={styles.remainingCount}>{remaining}</span>
+            <span className={styles.remainingLabel}>REMAINING</span>
+          </div>
+        </div>
       </div>
     </div>
   )

--- a/src/components/RoomBar.module.css
+++ b/src/components/RoomBar.module.css
@@ -1,26 +1,32 @@
+/* ── Room Bar (two-row header) ── */
 .bar {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  margin-bottom: 18px;
+}
+
+/* Top row: back button, room title, share buttons & theme */
+.topRow {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 8px 16px;
-  background: var(--surface);
-  border: 1px solid var(--border);
-  margin-bottom: 20px;
-  flex-wrap: wrap;
-  gap: 8px;
-}
-
-.left {
-  display: flex;
-  align-items: center;
+  padding: 10px 16px;
   gap: 12px;
   flex-wrap: wrap;
 }
 
-.right {
+.topLeft {
   display: flex;
   align-items: center;
-  gap: 6px;
+  gap: 12px;
+  min-width: 0;
+}
+
+.topRight {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-shrink: 0;
 }
 
 .backBtn {
@@ -36,6 +42,7 @@
   padding: 5px 12px;
   cursor: pointer;
   transition: all 0.15s;
+  flex-shrink: 0;
 }
 
 .backBtn svg {
@@ -54,75 +61,39 @@
 
 .sep {
   width: 1px;
-  height: 20px;
+  height: 22px;
   background: var(--border);
   flex-shrink: 0;
 }
 
-.roomInfo {
+/* Room title (prominent) */
+.roomTitle {
   display: flex;
   align-items: center;
   gap: 8px;
+  min-width: 0;
 }
 
-.label {
-  font-family: 'Share Tech Mono', monospace;
-  font-size: 9px;
-  letter-spacing: 0.2em;
-  color: var(--text-dim);
+.bolt {
+  font-size: 18px;
+  line-height: 1;
+  filter: drop-shadow(0 0 6px rgba(245, 166, 35, 0.5));
+  flex-shrink: 0;
 }
 
-.code {
+.roomNameBig {
   font-family: 'Orbitron', monospace;
-  font-size: 14px;
-  font-weight: 700;
-  letter-spacing: 0.15em;
-  color: var(--amber);
-}
-
-.roomName {
-  font-family: 'IBM Plex Mono', monospace;
-  font-size: 12px;
-  color: var(--text);
-  font-weight: 500;
-  padding-left: 8px;
-  border-left: 1px solid var(--border);
-}
-
-.presence {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-}
-
-.presenceDot {
-  width: 6px;
-  height: 6px;
-  border-radius: 50%;
-  background: var(--green);
-  box-shadow: 0 0 6px var(--green);
-  animation: pulse 1.5s infinite;
-}
-
-@keyframes pulse {
-  0%, 100% { opacity: 1; }
-  50% { opacity: 0.4; }
-}
-
-.presenceCount {
-  font-family: 'Orbitron', monospace;
-  font-size: 12px;
+  font-size: clamp(14px, 3vw, 20px);
   font-weight: 700;
   color: var(--text);
+  letter-spacing: 0.06em;
+  line-height: 1.2;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
-.presenceLabel {
-  font-family: 'Share Tech Mono', monospace;
-  font-size: 9px;
-  letter-spacing: 0.15em;
-  color: var(--text-dim);
-}
-
+/* Share buttons */
 .shareBtn {
   display: flex;
   align-items: center;
@@ -161,14 +132,128 @@
   stroke: var(--green);
 }
 
+/* Bottom row: status strip */
+.statusStrip {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 6px 16px;
+  border-top: 1px solid var(--border);
+  background: var(--bg);
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.statusLeft {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.statusRight {
+  display: flex;
+  align-items: center;
+}
+
+.statusItem {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-family: 'Share Tech Mono', monospace;
+  font-size: 10px;
+  letter-spacing: 0.12em;
+  color: var(--text-dim);
+}
+
+.statusSep {
+  width: 1px;
+  height: 12px;
+  background: var(--border);
+  flex-shrink: 0;
+}
+
+.statusDot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+}
+
+.dotLive {
+  background: var(--green);
+  box-shadow: 0 0 6px var(--green);
+  animation: pulse 1.5s infinite;
+}
+
+.dotConnecting {
+  background: var(--amber);
+  box-shadow: 0 0 6px var(--amber);
+  animation: pulse 1.5s infinite;
+}
+
+.dotOffline {
+  background: var(--red);
+  box-shadow: 0 0 6px var(--red);
+}
+
+.presenceDot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--green);
+  box-shadow: 0 0 6px var(--green);
+  animation: pulse 1.5s infinite;
+  display: inline-block;
+}
+
+.statusCode {
+  font-family: 'Orbitron', monospace;
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  color: var(--amber);
+}
+
+@keyframes pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.4; }
+}
+
+/* Remaining badge */
+.remainingBadge {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.remainingCount {
+  font-family: 'Orbitron', monospace;
+  font-size: 16px;
+  font-weight: 700;
+  color: var(--amber);
+  line-height: 1;
+}
+
+.remainingLabel {
+  font-family: 'Share Tech Mono', monospace;
+  font-size: 9px;
+  letter-spacing: 0.15em;
+  color: var(--text-dim);
+}
+
+/* ── Responsive ── */
 @media (max-width: 600px) {
-  .bar {
+  .topRow {
     flex-direction: column;
     align-items: flex-start;
+    gap: 8px;
   }
-  
-  .right {
+
+  .topRight {
     width: 100%;
     justify-content: flex-end;
+  }
+
+  .roomNameBig {
+    font-size: 14px;
   }
 }

--- a/src/components/TimerPanel.module.css
+++ b/src/components/TimerPanel.module.css
@@ -1,8 +1,8 @@
 .panel {
   background: var(--surface);
   border: 1px solid var(--border);
-  padding: 28px 28px 24px;
-  margin-bottom: 28px;
+  padding: 22px 24px 18px;
+  margin-bottom: 18px;
   position: relative;
 }
 


### PR DESCRIPTION
- Remove redundant Header from room view
- Move TimerPanel above JoinSection so it's visible without scrolling
- Redesign RoomBar with room name, status, remaining count, theme toggle
- Compact spacing throughout room view
- Bump version to v3.1

Closes #4, closes #8