### PR TITLE
fix: keep public rooms in lobby with heartbeat + add loading placeholders

### DIFF
--- a/src/components/HomeScreen.jsx
+++ b/src/components/HomeScreen.jsx
@@ -33,7 +33,7 @@ export function HomeScreen({ onCreateRoom, onJoinRoom, theme, onThemeToggle }) {
   const [input, setInput] = useState('')
   const [isPublic, setIsPublic] = useState(false)
   const [error, setError] = useState('')
-  const { publicRooms } = useLobby()
+  const { publicRooms, lobbyReady } = useLobby()
   const inputRef = useRef(null)
 
   useEffect(() => {
@@ -191,10 +191,27 @@ export function HomeScreen({ onCreateRoom, onJoinRoom, theme, onThemeToggle }) {
         <div className={styles.lobby}>
           <div className={styles.lobbyHeader}>
             <span className={styles.lobbyTitle}>// PUBLIC ROOMS</span>
-            <span className={styles.lobbyCount}>{sortedRooms.length} ACTIVE</span>
+            {lobbyReady ? (
+              <span className={styles.lobbyCount}>{sortedRooms.length} ACTIVE</span>
+            ) : (
+              <span className={`${styles.lobbyCount} ${styles.shimmerText}`}>— LOADING</span>
+            )}
           </div>
 
-          {sortedRooms.length === 0 ? (
+          {!lobbyReady ? (
+            /* Skeleton placeholder cards while Ably channel is attaching */
+            <div className={styles.roomList}>
+              {[1, 2, 3].map((i) => (
+                <div key={i} className={styles.skeletonCard}>
+                  <div className={styles.skeletonInfo}>
+                    <div className={`${styles.skeletonBar} ${styles.skeletonBarWide}`} />
+                    <div className={styles.skeletonBar} />
+                  </div>
+                  <div className={`${styles.skeletonBar} ${styles.skeletonBarCircle}`} />
+                </div>
+              ))}
+            </div>
+          ) : sortedRooms.length === 0 ? (
             <div className={styles.emptyLobby}>
               <div className={styles.emptyIcon}>⚡</div>
               <p>NO PUBLIC ROOMS ACTIVE<br />CREATE ONE TO GET STARTED</p>

--- a/src/components/HomeScreen.module.css
+++ b/src/components/HomeScreen.module.css
@@ -486,3 +486,61 @@
   color: var(--amber);
   font-weight: 400;
 }
+
+/* ── Skeleton / shimmer placeholders ── */
+@keyframes shimmer {
+  0%   { background-position: -200% 0; }
+  100% { background-position: 200% 0; }
+}
+
+.shimmerText {
+  animation: shimmerPulse 1.4s ease-in-out infinite;
+}
+
+@keyframes shimmerPulse {
+  0%, 100% { opacity: 0.4; }
+  50%      { opacity: 1; }
+}
+
+.skeletonCard {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 14px 18px;
+  border-bottom: 1px solid var(--border);
+}
+
+.skeletonCard:last-child {
+  border-bottom: none;
+}
+
+.skeletonInfo {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.skeletonBar {
+  height: 10px;
+  width: 80px;
+  border-radius: 4px;
+  background: linear-gradient(
+    90deg,
+    var(--surface2) 25%,
+    var(--border) 50%,
+    var(--surface2) 75%
+  );
+  background-size: 200% 100%;
+  animation: shimmer 1.6s ease-in-out infinite;
+}
+
+.skeletonBarWide {
+  width: 140px;
+  height: 14px;
+}
+
+.skeletonBarCircle {
+  width: 28px;
+  height: 12px;
+  border-radius: 6px;
+}

--- a/src/components/Room.jsx
+++ b/src/components/Room.jsx
@@ -30,7 +30,7 @@ export function Room({ roomId, roomUrl, roomConfig, theme, onThemeToggle, onLeav
   const [sidebarOpen, setSidebarOpen] = useState(false)
   const [notesUnread, setNotesUnread] = useState(false)
   const sidebarOpenRef = useRef(false)
-  const { memberCount, isLastOne } = useRoomPresence({ roomId })
+  const { memberCount, isLastOne, presenceReady } = useRoomPresence({ roomId })
   const { publishRoomUpdate } = useLobby()
   const hasHadContentRef = useRef(false)
   const leaveWarningShownRef = useRef(false)
@@ -65,9 +65,12 @@ export function Room({ roomId, roomUrl, roomConfig, theme, onThemeToggle, onLeav
     if (hasContent) hasHadContentRef.current = true
   }, [])
 
-  // Publish room presence updates to lobby if public
+  // Publish room presence updates to lobby if public,
+  // and keep the listing alive with a periodic heartbeat.
   useEffect(() => {
-    if (roomConfig?.isPublic && roomId) {
+    if (!roomConfig?.isPublic || !roomId) return
+
+    const sendUpdate = () => {
       publishRoomUpdate({
         id: roomId,
         name: roomConfig.name || '',
@@ -75,6 +78,14 @@ export function Room({ roomId, roomUrl, roomConfig, theme, onThemeToggle, onLeav
         isPublic: true,
       })
     }
+
+    // Publish immediately on every memberCount change
+    sendUpdate()
+
+    // Re-publish every 60 s so the lobby's rewind buffer stays fresh
+    // and the stale-room pruner doesn't remove this entry.
+    const heartbeat = setInterval(sendUpdate, 60_000)
+    return () => clearInterval(heartbeat)
   }, [memberCount, roomId, roomConfig, publishRoomUpdate])
 
   // Show warning when user is the last one and is about to leave
@@ -88,28 +99,15 @@ export function Room({ roomId, roomUrl, roomConfig, theme, onThemeToggle, onLeav
     }
   }, [isLastOne, showToast])
 
-  // Handle room leave with cleanup logic
+  // Handle room leave.
+  // The lobby entry is kept alive by the heartbeat interval above;
+  // once this component unmounts the heartbeats stop, and the lobby's
+  // stale-room pruner will automatically remove the entry.
   const handleLeave = useCallback(() => {
-    if (hasHadContentRef.current) {
-      // Room had content — it'll be cleaned up 30s after last person leaves
-      // The cleanup happens automatically via presence-based logic
-      if (roomConfig?.isPublic) {
-        // Delay marking as removed so the lobby updates after presence detaches
-        setTimeout(() => {
-          publishRoomUpdate({
-            id: roomId,
-            removed: true,
-          })
-        }, 30000)
-      }
-    } else {
-      // Room was empty / no content — clean immediately
-      if (roomConfig?.isPublic) {
-        publishRoomUpdate({
-          id: roomId,
-          removed: true,
-        })
-      }
+    // If the room is empty (no content), remove it from the lobby immediately
+    // so it doesn't linger for the full stale timeout.
+    if (!hasHadContentRef.current && roomConfig?.isPublic) {
+      publishRoomUpdate({ id: roomId, removed: true })
     }
     onLeave()
   }, [onLeave, roomId, roomConfig, publishRoomUpdate])
@@ -345,6 +343,7 @@ export function Room({ roomId, roomUrl, roomConfig, theme, onThemeToggle, onLeav
           remaining={waiting.length + (active ? 1 : 0)}
           isConnected={isConnected}
           isConnecting={isConnecting}
+          presenceReady={presenceReady}
           theme={theme}
           onThemeToggle={onThemeToggle}
           onLeave={handleLeave}

--- a/src/components/RoomBar.jsx
+++ b/src/components/RoomBar.jsx
@@ -27,7 +27,7 @@ const IconCheck = () => (
   </svg>
 )
 
-export function RoomBar({ roomId, roomUrl, roomName, memberCount, remaining, isConnected, isConnecting, theme, onThemeToggle, onLeave }) {
+export function RoomBar({ roomId, roomUrl, roomName, memberCount, remaining, isConnected, isConnecting, presenceReady, theme, onThemeToggle, onLeave }) {
   const [copied, setCopied] = useState(null) // 'link' | 'code' | null
 
   const copyToClipboard = useCallback((text, type) => {
@@ -106,7 +106,11 @@ export function RoomBar({ roomId, roomUrl, roomName, memberCount, remaining, isC
           <div className={styles.statusSep} />
           <div className={styles.statusItem}>
             <span className={styles.presenceDot} />
-            <span>{memberCount} CONNECTED</span>
+            {presenceReady ? (
+              <span>{memberCount} CONNECTED</span>
+            ) : (
+              <span className={styles.shimmerInline}>—</span>
+            )}
           </div>
           {roomName && (
             <>
@@ -119,7 +123,11 @@ export function RoomBar({ roomId, roomUrl, roomName, memberCount, remaining, isC
         </div>
         <div className={styles.statusRight}>
           <div className={styles.remainingBadge}>
-            <span className={styles.remainingCount}>{remaining}</span>
+            {presenceReady ? (
+              <span className={styles.remainingCount}>{remaining}</span>
+            ) : (
+              <span className={`${styles.remainingCount} ${styles.shimmerInline}`}>—</span>
+            )}
             <span className={styles.remainingLabel}>REMAINING</span>
           </div>
         </div>

--- a/src/components/RoomBar.module.css
+++ b/src/components/RoomBar.module.css
@@ -257,3 +257,14 @@
     font-size: 14px;
   }
 }
+
+/* ── Shimmer placeholder ── */
+.shimmerInline {
+  animation: shimmerPulse 1.4s ease-in-out infinite;
+  opacity: 0.4;
+}
+
+@keyframes shimmerPulse {
+  0%, 100% { opacity: 0.4; }
+  50%      { opacity: 1; }
+}

--- a/src/hooks/useLobby.js
+++ b/src/hooks/useLobby.js
@@ -3,14 +3,21 @@ import Ably from 'ably'
 
 const LOBBY_CHANNEL = 'lightning-ladder__lobby'
 
+/** Rooms not updated within this window are considered stale and pruned */
+const STALE_TIMEOUT_MS = 150_000 // 2.5 minutes
+const STALE_CHECK_INTERVAL_MS = 30_000 // check every 30 s
+
 /**
- * Manages the lobby: lists public rooms, tracks presence counts
+ * Manages the lobby: lists public rooms, tracks presence counts.
+ * Rooms are kept alive by periodic heartbeat messages from the Room
+ * component; entries that stop heartbeating are pruned automatically.
  */
 export function useLobby() {
   const clientRef = useRef(null)
   const channelRef = useRef(null)
   const isMounted = useRef(true)
   const [publicRooms, setPublicRooms] = useState([])
+  const [lobbyReady, setLobbyReady] = useState(false)
 
   useEffect(() => {
     isMounted.current = true
@@ -32,6 +39,12 @@ export function useLobby() {
     const channel = client.channels.get(LOBBY_CHANNEL, { params: { rewind: '1' } })
     channelRef.current = channel
 
+    // Once the channel attaches, rewind messages have been delivered,
+    // so we know the lobby state is up-to-date.
+    channel.once('attached', () => {
+      if (isMounted.current) setLobbyReady(true)
+    })
+
     // Subscribe to room list updates
     channel.subscribe('room-list', (message) => {
       if (isMounted.current && message.data) {
@@ -47,19 +60,32 @@ export function useLobby() {
           if (room.removed) {
             return prev.filter((r) => r.id !== room.id)
           }
+          // Stamp a local lastSeen so we can prune stale entries
+          const stamped = { ...room, lastSeen: Date.now() }
           const idx = prev.findIndex((r) => r.id === room.id)
           if (idx >= 0) {
             const next = [...prev]
-            next[idx] = room
+            next[idx] = stamped
             return next
           }
-          return [...prev, room]
+          return [...prev, stamped]
         })
       }
     })
 
+    // Periodically prune rooms whose heartbeat has stopped
+    const pruneInterval = setInterval(() => {
+      if (!isMounted.current) return
+      const now = Date.now()
+      setPublicRooms((prev) => {
+        const next = prev.filter((r) => now - (r.lastSeen || 0) < STALE_TIMEOUT_MS)
+        return next.length === prev.length ? prev : next
+      })
+    }, STALE_CHECK_INTERVAL_MS)
+
     return () => {
       isMounted.current = false
+      clearInterval(pruneInterval)
       channel.unsubscribe()
       client.close()
     }
@@ -69,5 +95,5 @@ export function useLobby() {
     channelRef.current?.publish('room-update', roomData)
   }, [])
 
-  return { publicRooms, publishRoomUpdate }
+  return { publicRooms, publishRoomUpdate, lobbyReady }
 }

--- a/src/hooks/useRoomPresence.js
+++ b/src/hooks/useRoomPresence.js
@@ -11,6 +11,7 @@ export function useRoomPresence({ roomId }) {
   const isMounted = useRef(true)
   const [memberCount, setMemberCount] = useState(0)
   const [isLastOne, setIsLastOne] = useState(false)
+  const [presenceReady, setPresenceReady] = useState(false)
 
   useEffect(() => {
     if (!roomId) return
@@ -41,6 +42,7 @@ export function useRoomPresence({ roomId }) {
         if (isMounted.current) {
           setMemberCount(count)
           setIsLastOne(count <= 1)
+          setPresenceReady(true)
         }
       } catch {
         // ignore
@@ -66,5 +68,5 @@ export function useRoomPresence({ roomId }) {
     }
   }, [roomId])
 
-  return { memberCount, isLastOne }
+  return { memberCount, isLastOne, presenceReady }
 }


### PR DESCRIPTION
- Add 60s heartbeat in Room so lobby entry survives Ably rewind TTL
- Prune stale rooms (>2.5min without heartbeat) in useLobby
- Remove broken 30s setTimeout in handleLeave (fired after unmount)
- Add lobbyReady/presenceReady flags to prevent flash of empty state
- Show skeleton shimmer cards in lobby and RoomBar while loading

Closes #5